### PR TITLE
Set fzf height to 40% to prevent taking up the entire terminal

### DIFF
--- a/bd.zsh
+++ b/bd.zsh
@@ -19,7 +19,7 @@ bd () {
     if type fzf &> /dev/null
     then
       local IFS=$'\n'
-      arg="$(fzf <<< $parents)"
+      arg="$(fzf --height=40% <<< $parents)"
       result=$?
       unset IFS
       if [ $result -gt 0 ]


### PR DESCRIPTION
Setting fzf's height to 40% is much nicer because it will not take up the entire terminal. Also, official fzf keybinds for zsh also do this.